### PR TITLE
Help Menu Functionality for Components and Paradigms

### DIFF
--- a/GME/Gme/GME.rc
+++ b/GME/Gme/GME.rc
@@ -1,21 +1,17 @@
 // Microsoft Visual C++ generated resource script.
 //
-#include "resource.h"
-
+#include "resource.h"
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
 #include "afxres.h"
-#include "GMEVersion.h"
-
+#include "GMEVersion.h"
 /////////////////////////////////////////////////////////////////////////////
-#undef APSTUDIO_READONLY_SYMBOLS
-
+#undef APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
-// English (United States) resources
-
+// English (United States) resources
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
@@ -255,6 +251,8 @@ BEGIN
     END
     POPUP "&Help"
     BEGIN
+        MENUITEM "&Paradigm Help",              ID_HELP_PARADIGMHELP
+        MENUITEM "C&omponent Help",             ID_HELP_COMPONENTHELP
         MENUITEM "&Contents",                   ID_HELP_CONTENTS
         MENUITEM "&About GME...",               ID_APP_ABOUT
     END
@@ -396,6 +394,8 @@ BEGIN
     END
     POPUP "&Help"
     BEGIN
+        MENUITEM "&Paradigm Help",              ID_HELP_PARADIGMHELP
+        MENUITEM "C&omponent Help",             ID_HELP_COMPONENTHELP
         MENUITEM "&Contents",                   ID_HELP_CONTENTS
         MENUITEM "&Help",                       ID_HELP_HELP
         MENUITEM "&About GME...",               ID_APP_ABOUT
@@ -1789,4 +1789,3 @@ LANGUAGE 9, 1
 1 TYPELIB "GmeLib.tlb"
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/GME/Gme/GMEApp.cpp
+++ b/GME/Gme/GMEApp.cpp
@@ -144,7 +144,7 @@ CGMEApp theApp;
 
 /*static*/ const TCHAR * CGMEApp::m_no_model_open_string = _T("_NO_MODEL_IS_OPEN_");
 
-static CComBSTR StringFromGUID2(const CComVariant& guid)
+CComBSTR StringFromGUID2(const CComVariant& guid)
 {
 	ASSERT(guid.vt == (VT_UI1 | VT_ARRAY));
 	GUID guid2;
@@ -1353,8 +1353,8 @@ void CGMEApp::UpdateDynMenus(CMenu *toolmenu)
 				for (int i = 0; i < min(plugins.GetSize() + interpreters.GetSize() + addons.GetSize(), ID_HELP_COMPONENTHELP_LAST - ID_HELP_COMPONENTHELP_FIRST);) {
 					int index = i / 2;
 					CString componentName = (index < plugins.GetSize() ? 
-							plugins[index] : (index < plugins.GetSize() + interpreters.GetSize() ? 
-								interpreters[index - plugins.GetSize()] : addons[index - plugins.GetSize() - interpreters.GetSize()]));
+						pluginTooltips[index] : (index < plugins.GetSize() + interpreters.GetSize() ?
+						interpreterTooltips[index - plugins.GetSize()] : addons[index - plugins.GetSize() - interpreters.GetSize()]));
 					CString onlineHelpLocation = (index < plugins.GetSize() ? 
 							pluginOnlineHelp[index] : (index < plugins.GetSize() + interpreters.GetSize() ? 
 								interpreterOnlineHelp[index - plugins.GetSize()] : addonOnlineHelp[index - plugins.GetSize() - interpreters.GetSize()]));
@@ -1398,24 +1398,14 @@ void CGMEApp::UpdateDynMenus(CMenu *toolmenu)
 		{
 			if (dynmenus_need_refresh && mgaProject) {
 				toolmenu->DeleteMenu(idx, MF_BYPOSITION);
-				CComBSTR pname;
-				CComVariant pguid;
-				CComBSTR pguidstr;
-				{
-					CComPtr<IMgaTerritory> t;
-					COMTHROW(mgaProject->CreateTerritory(NULL, &t, NULL));
-					COMTHROW(mgaProject->BeginTransaction(t, TRANSACTION_READ_ONLY));
-					COMTHROW(mgaProject->get_MetaName(&pname));
-					COMTHROW(mgaProject->get_MetaGUID(&pguid));
-					pguidstr = StringFromGUID2(pguid);
-					COMTHROW(mgaProject->CommitTransaction());
-				}
+				CComBSTR pname = guiMetaProject->name;
+				CComBSTR pguidstr = guiMetaProject->guid;
 
 				CMenu help;
 				help.CreatePopupMenu();
 				CComPtr<IMgaRegistrar2> reg;
 				HRESULT hr = reg.CoCreateInstance(CComBSTR(L"Mga.MgaRegistrar"));
-				if (hr == S_OK)
+				if (SUCCEEDED(hr))
 				{
 					reg->GetParadigmExtraInfoDisp(pname, pguidstr, CComBSTR(L"OnlineHelp"), PutOut(this->paradigmOnlineHelp));
 					reg->GetParadigmExtraInfoDisp(pname, pguidstr, CComBSTR(L"OfflineHelp"), PutOut(this->paradigmOfflineHelp));
@@ -3134,18 +3124,11 @@ void CGMEApp::OnRunComponentHelp(UINT nID) {
 
 void CGMEApp::OnRunParadigmHelp(UINT nID)
 {
-	CComBSTR pname;
-	{
-		CComPtr<IMgaTerritory> t;
-		COMTHROW(mgaProject->CreateTerritory(NULL, &t, NULL));
-		COMTHROW(mgaProject->BeginTransaction(t, TRANSACTION_READ_ONLY));
-		COMTHROW(mgaProject->get_MetaName(&pname));
-		COMTHROW(mgaProject->CommitTransaction());
-	}
+	CComBSTR pname = guiMetaProject->name;
 
 	CGMEEventLogger::LogGMEEvent((_T("CGMEApp::OnRunParadigmHelp ") +
 		std::wstring(static_cast<const wchar_t*>(pname)) + _T("\r\n")).c_str());
-
+  
 	CString help = (nID == ID_HELP_PARADIGMHELP_FIRST ? this->paradigmOnlineHelp : this->paradigmOfflineHelp);
 	if (!help.IsEmpty())
 	{

--- a/GME/Gme/GMEApp.h
+++ b/GME/Gme/GMEApp.h
@@ -51,6 +51,9 @@ public:
 //  dynamic menus
 	CStringArray plugins, interpreters, addons;
     CStringArray pluginTooltips, interpreterTooltips, addonToolTips;
+	CStringArray pluginOnlineHelp, interpreterOnlineHelp, addonOnlineHelp;
+	CStringArray pluginOfflineHelp, interpreterOfflineHelp, addonOfflineHelp;
+	CString paradigmOnlineHelp, paradigmOfflineHelp;
 	bool dynmenus_need_refresh;
 
 	// Application look
@@ -233,6 +236,8 @@ public:
 	afx_msg void OnFileXMLUpdate();
 	afx_msg void OnRunPlugin(UINT nID);
 	afx_msg void OnRunInterpreter(UINT nID);
+	afx_msg void OnRunComponentHelp(UINT nID);
+	afx_msg void OnRunParadigmHelp(UINT nID);
 	afx_msg void OnUpdateFilePluginX(CCmdUI* pCmdUI);
 	afx_msg void OnUpdateFileInterpretX(CCmdUI* pCmdUI);
 	afx_msg void OnFileDisplayConstraints();

--- a/GME/Gme/GMEApp.h
+++ b/GME/Gme/GMEApp.h
@@ -50,7 +50,7 @@ public:
 	CComPtr<IMgaMetaProject> mgaMetaProject;
 //  dynamic menus
 	CStringArray plugins, interpreters, addons;
-    CStringArray pluginTooltips, interpreterTooltips, addonToolTips;
+	CStringArray pluginTooltips, interpreterTooltips, addonToolTips;
 	CStringArray pluginOnlineHelp, interpreterOnlineHelp, addonOnlineHelp;
 	CStringArray pluginOfflineHelp, interpreterOfflineHelp, addonOfflineHelp;
 	CString paradigmOnlineHelp, paradigmOfflineHelp;

--- a/GME/Gme/GuiMeta.cpp
+++ b/GME/Gme/GuiMeta.cpp
@@ -5,6 +5,7 @@
 #include "GuiMeta.h"
 #include "GuiObject.h"
 
+CComBSTR StringFromGUID2(const CComVariant& guid);
 
 // helper functions
 
@@ -65,6 +66,11 @@ CGuiMetaProject::CGuiMetaProject(CComPtr<IMgaMetaProject> &mgaPt)
 			CComBSTR bstr;
 			COMTHROW(mgaMeta->get_DisplayedName(&bstr));
 			CopyTo(bstr,displayedName);
+		}
+		{
+			CComVariant pguid;
+			COMTHROW(mgaMeta->get_GUID(&pguid));
+			guid = StringFromGUID2(pguid);
 		}
 
 		CComPtr<IMgaMetaFolder> mmFolder;

--- a/GME/Gme/GuiMeta.h
+++ b/GME/Gme/GuiMeta.h
@@ -15,6 +15,7 @@ public:
 	~CGuiMetaProject();
 public:
 	CString name;
+	CString guid;
 	CString displayedName;
 	CGuiMetaFolder *rootFolder;
 	CGuiMetaBaseTable metaTable;

--- a/GME/Gme/MainFrm.cpp
+++ b/GME/Gme/MainFrm.cpp
@@ -94,6 +94,7 @@ BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWndEx)
 	ON_UPDATE_COMMAND_UI(ID_MULTIUSER_ACTIVEUSERS, OnUpdateViewMultiUserActiveUsers)
 	ON_COMMAND(ID_VIEW_CLEARCONSOLE, OnViewClearConsole)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_CLEARCONSOLE, OnUpdateViewClearConsole)
+	ON_UPDATE_COMMAND_UI(ID_HELP_CONTENTS, OnUpdateFileSettings)
 
 #define MSG_MAP_VIEW_PANE(ID, class_, member) \
 	ON_COMMAND(ID, (&CMainFrame::OnViewPane<class_, &CMainFrame::member>)) \
@@ -457,7 +458,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 	mdiTabParams.m_tabLocation = CMFCTabCtrl::LOCATION_TOP;	// Specifies that the tabs labels are located at the top of the page
 	EnableMDITabbedGroups(TRUE, mdiTabParams);
 
-	CMFCToolBar::EnableQuickCustomization();
+ 	CMFCToolBar::EnableQuickCustomization();
 
 	// Set the visual manager and style based on persisted value
 	OnApplicationLook(theApp.m_nAppLook);
@@ -1266,6 +1267,13 @@ void CMainFrame::OnViewClearConsole()
 void CMainFrame::OnUpdateViewClearConsole(CCmdUI* pCmdUI) 
 {
 	pCmdUI->Enable();
+}
+
+void CMainFrame::OnUpdateFileSettings(CCmdUI* pCmdUI)
+{
+	// This is an update message for Tools/Options menu
+	// This triggers the refresh of plugins/interpreters menus
+	theApp.UpdateDynMenus(pCmdUI->m_pMenu);
 }
 
 void CMainFrame::OnDropFiles(HDROP p_hDropInfo)

--- a/GME/Gme/MainFrm.h
+++ b/GME/Gme/MainFrm.h
@@ -165,6 +165,7 @@ protected:
 	afx_msg void OnUpdateViewMultiUserSubversion(CCmdUI* pCmdUI);
 	afx_msg void OnViewClearConsole();
 	afx_msg void OnUpdateViewClearConsole( CCmdUI* pCmdUI);
+	afx_msg void OnUpdateFileSettings(CCmdUI* pCmdUI);
 
 	template<class paneclass, typename paneclass CMainFrame::* const m_pane> afx_msg void OnViewPane() 
 	{

--- a/GME/Gme/resource.h
+++ b/GME/Gme/resource.h
@@ -520,16 +520,22 @@
 #define ID_CONNCNTX_REVERSE             33270
 #define ID_VIEW_SHOWCONNECTEDPORTSONLY  33271
 #define ID_PORTCNTX_DELETE              33272
+#pragma region Help IDs
+#define ID_HELP_PARADIGMHELP            0x9000
+#define ID_HELP_PARADIGMHELP_FIRST      0x9001
+#define ID_HELP_PARADIGMHELP_LAST       0x900F
+#define ID_HELP_COMPONENTHELP           0x9010
+#define ID_HELP_COMPONENTHELP_FIRST     0x9011
+#define ID_HELP_COMPONENTHELP_LAST      0x908F
+#pragma endregion
 #define IDW_TOOLBAR_MAIN                0xE820
 #define IDW_TOOLBAR_WINS                0xE821
 #define IDW_TOOLBAR_COMPONENT           0xE822
 #define IDW_TOOLBAR_MODE                0xE823
 #define IDW_TOOLBAR_NAVIG               0xE824
 #define IDW_TOOLBAR_MODELING            0xE825
-
-
-#define ID_FILE_INTERPRET_LAST ID_FILE_INTERPRET49
 #define ID_FILE_RUNPLUGIN_LAST ID_FILE_RUNPLUGIN8
+#define ID_FILE_INTERPRET_LAST ID_FILE_INTERPRET49
 
 // Next default values for new objects
 // 

--- a/GME/Interfaces/MgaUtil.idl
+++ b/GME/Interfaces/MgaUtil.idl
@@ -517,6 +517,28 @@ interface IMgaRegistrar : IDispatch
 	HRESULT UnregisterComponentLibrary([in] BSTR path, [in] regaccessmode_enum mode);
 };
 
+[
+	object,
+	uuid(0E3C2752-6173-4050-BD47-AE54DA1C373A),
+	dual,
+	helpstring("IMgaRegistrar2 Interface"),
+	pointer_default(unique)
+]
+interface IMgaRegistrar2 : IMgaRegistrar
+{
+	[propput, helpstring("property ParadigmExtraInfo")]
+	HRESULT ParadigmExtraInfo([in] regaccessmode_enum mode, [in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [in] BSTR newVal);
+
+	[propget, helpstring("property ParadigmExtraInfo")]
+	HRESULT ParadigmExtraInfo([in] regaccessmode_enum mode, [in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [out, retval] BSTR *pVal);
+
+	[helpstring("setter for property ParadigmExtraInfo")]
+	HRESULT SetParadigmExtraInfoDisp([in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [in] BSTR newVal, [in, defaultvalue(REGACCESS_BOTH)] regaccessmode_enum mode);
+
+	[helpstring("getter for property ParadigmExtraInfo")]
+	HRESULT GetParadigmExtraInfoDisp([in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [out, retval] BSTR *pVal);
+};
+
 typedef enum metadlg_enum
 {
 	METADLG_NONE =		0x0000,

--- a/GME/Interfaces/MgaUtil.idl
+++ b/GME/Interfaces/MgaUtil.idl
@@ -533,7 +533,7 @@ interface IMgaRegistrar2 : IMgaRegistrar
 	HRESULT ParadigmExtraInfo([in] regaccessmode_enum mode, [in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [out, retval] BSTR *pVal);
 
 	[helpstring("setter for property ParadigmExtraInfo")]
-	HRESULT SetParadigmExtraInfoDisp([in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [in] BSTR newVal, [in, defaultvalue(REGACCESS_BOTH)] regaccessmode_enum mode);
+	HRESULT SetParadigmExtraInfoDisp([in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [in] BSTR newVal, [in, defaultvalue(REGACCESS_SYSTEM)] regaccessmode_enum mode);
 
 	[helpstring("getter for property ParadigmExtraInfo")]
 	HRESULT GetParadigmExtraInfoDisp([in] BSTR ParadigmName, [in] BSTR ParadigmVersionGUID, [in] BSTR name, [out, retval] BSTR *pVal);

--- a/GME/MgaUtil/MgaRegistrar.cpp
+++ b/GME/MgaUtil/MgaRegistrar.cpp
@@ -2423,7 +2423,7 @@ STDMETHODIMP CMgaRegistrar::UnregisterComponentLibrary(BSTR path, regaccessmode_
 		{
 			--index;
 			CComObjPtr<ITypeInfo> typeinfo;
-			COMTHROW( typelib->GetTypeInfo(index, PutOut(typeinfo)) );// index parameter with the range of 0 to GetTypeInfoCount() –1.
+			COMTHROW( typelib->GetTypeInfo(index, PutOut(typeinfo)) );// index parameter with the range of 0 to GetTypeInfoCount() Â–1.
 
 			TYPEATTR *typeattr = NULL;
 			COMTHROW( typeinfo->GetTypeAttr(&typeattr) );

--- a/GME/MgaUtil/MgaRegistrar.h
+++ b/GME/MgaUtil/MgaRegistrar.h
@@ -8,8 +8,8 @@
 class ATL_NO_VTABLE CMgaRegistrar : 
 	public CComObjectRootEx<CComSingleThreadModel>,
 	public CComCoClass<CMgaRegistrar, &__uuidof(MgaRegistrar)>,
-	public IDispatchImpl<IMgaRegistrar, &__uuidof(IMgaRegistrar), &__uuidof(__MGAUtilLib)>,
-	public ISupportErrorInfoImpl<&__uuidof(IMgaRegistrar)>,
+	public IDispatchImpl<IMgaRegistrar2, &__uuidof(IMgaRegistrar2), &__uuidof(__MGAUtilLib)>,
+	public ISupportErrorInfoImpl2<&__uuidof(IMgaRegistrar), &__uuidof(IMgaRegistrar2)>,
 	public IGMEVersionInfoImpl
 {
 public:
@@ -20,7 +20,8 @@ DECLARE_PROTECT_FINAL_CONSTRUCT()
 
 BEGIN_COM_MAP(CMgaRegistrar)
 	COM_INTERFACE_ENTRY(IMgaRegistrar)
-	COM_INTERFACE_ENTRY(IDispatch)
+	COM_INTERFACE_ENTRY(IMgaRegistrar2)
+	COM_INTERFACE_ENTRY2(IDispatch, IMgaRegistrar2)
 	COM_INTERFACE_ENTRY(ISupportErrorInfo)
 	COM_INTERFACE_ENTRY_IID(__uuidof(IGMEVersionInfo), IGMEVersionInfoImpl)
 END_COM_MAP()
@@ -141,6 +142,13 @@ public:
 
 	STDMETHOD(RegisterComponentLibrary)(BSTR path, regaccessmode_enum mode);
 	STDMETHOD(UnregisterComponentLibrary)(BSTR path, regaccessmode_enum mode);
+
+	// --- IMgaRegistrar2
+
+	STDMETHOD(put_ParadigmExtraInfo)(regaccessmode_enum mode, BSTR paradigmName, BSTR paradigmVersionGuid, BSTR name, BSTR newVal);
+	STDMETHOD(get_ParadigmExtraInfo)(regaccessmode_enum mode, BSTR paradigmName, BSTR paradigmVersionGuid, BSTR name, BSTR* pVal);
+	STDMETHOD(SetParadigmExtraInfoDisp)(BSTR paradigmName, BSTR paradigmVersionGuid, BSTR name, BSTR newVal, regaccessmode_enum mode = REGACCESS_SYSTEM) { return this->put_ParadigmExtraInfo(mode, paradigmName, paradigmVersionGuid, name, newVal); }
+	STDMETHOD(GetParadigmExtraInfoDisp)(BSTR paradigmName, BSTR paradigmVersionGuid, BSTR name, BSTR* pVal) { return this->get_ParadigmExtraInfo(REGACCESS_BOTH, paradigmName, paradigmVersionGuid, name, pVal); }
 };
 
 #endif//MGA_MGAREGISTRAR_H

--- a/GME/MgaUtil/MgaUtil.vcxproj
+++ b/GME/MgaUtil/MgaUtil.vcxproj
@@ -115,6 +115,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/w34189 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/GME/MgaUtil/MgaUtilLib.idl
+++ b/GME/MgaUtil/MgaUtilLib.idl
@@ -38,7 +38,8 @@ library MGAUtilLib
 	]
 	coclass MgaRegistrar
 	{
-		[default] interface IMgaRegistrar;
+		[default] interface IMgaRegistrar2;
+		interface IMgaRegistrar;
 		interface IGMEVersionInfo;
 	};
 

--- a/GME/MgaUtil/StdAfx.h
+++ b/GME/MgaUtil/StdAfx.h
@@ -109,6 +109,18 @@ typedef GMEInterfaceVersion_enum GMEInterfaceVersion;
 #include "Resource.h"
 
 regaccessmode_enum regacc_translate(int x);
+
+template <const IID* piid1, const IID* piid2>
+class ATL_NO_VTABLE ISupportErrorInfoImpl2 :
+	public ISupportErrorInfo
+{
+public:
+	STDMETHOD(InterfaceSupportsErrorInfo)(_In_ REFIID riid)
+	{
+		return (InlineIsEqualGUID(riid, *piid1) || InlineIsEqualGUID(riid, *piid2)) ? S_OK : S_FALSE;
+	}
+};
+
 //{{AFX_INSERT_LOCATION}}
 // Microsoft Visual C++ will insert additional declarations immediately before the previous line.
 

--- a/Install/GME_bin.wxs
+++ b/Install/GME_bin.wxs
@@ -511,6 +511,7 @@
                   <ProgId Id="Mga.MgaRegistrar" Description="MgaRegistrar Class" />
                 </ProgId>
                 <Interface Id="{F1D6BB05-42EE-11D4-B3F4-005004D38590}" Name="IMgaRegistrar"  ProxyStubClassId="{00020424-0000-0000-C000-000000000046}" ProxyStubClassId32="{00020424-0000-0000-C000-000000000046}" />
+                <Interface Id="{0E3C2752-6173-4050-BD47-AE54DA1C373A}" Name="IMgaRegistrar2"  ProxyStubClassId="{00020424-0000-0000-C000-000000000046}" ProxyStubClassId32="{00020424-0000-0000-C000-000000000046}" />
               </Class>
               <Class Id="{D03EC327-447B-11D4-B3F6-005004D38590}" Context="InprocServer32" Description="MgaLauncher Class" ThreadingModel="apartment" Programmable="yes">
                 <ProgId Id="Mga.MgaLauncher.1" Description="MgaLauncher Class">


### PR DESCRIPTION
Registry keys will be used to provide help documentation for paradigms and components.
Registry string values may be a website, local HTML file, or basically any file type.
If the registry key is set then a help menu will be visible on the main menu bar.

For Paradigms: (Main Menu)>Help>ParadigmName>(Online/Offline Help)
For Components: (Main Menu)>Help>Component Help>ComponentName>(Online/Offline Help)

Component Registry Keys: 
(HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE)>SOFTWARE>WOW6432NODE>GME>Components>ComponentName>OnlineHelp
(HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE)>SOFTWARE>WOW6432NODE>GME>Components>ComponentName>OfflineHelp

Paradigm Registry Keys:
(HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE)>SOFTWARE>WOW6432NODE>GME>Paradigms>ParadigmName>{ParadigmVersionUUID}>OnlineHelp
(HKEY_CURRENT_USER/HKEY_LOCAL_MACHINE)>SOFTWARE>WOW6432NODE>GME>Paradigms>ParadigmName>{ParadigmVersionUUID}>OfflineHelp